### PR TITLE
.github/workflows: Update Artifact Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Create source and wheel dist
       run: |
         python -m build
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: package distribution
         path: dist/


### PR DESCRIPTION
Currently, we're running the GitHub Artifact Actions v3 or lower, which will be deprecated by
2025-01-31, as noticed in [this blog post](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/).

This updates the actions to version 4 in order to avoid workflow failure.